### PR TITLE
Item search

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,7 +1,6 @@
 $(function(){
 
   function appendItem(item){
-    console.log(item);
     if(item.buy_history){
       var html = `
                   <a class="one_item item_soldout__parent search_item" href="/items/${item.id}">

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,0 +1,84 @@
+$(function(){
+
+  function appendItem(item){
+    console.log(item);
+    if(item.buy_history){
+      var html = `
+                  <a class="one_item item_soldout__parent search_item" href="/items/${item.id}">
+                    <div class="one_item__image_area item_soldout__children">
+                      <img src="${window.location.origin}${item.image}">
+                    </div>
+                    <div class="one_item__text_area">
+                      <div class="one_item__text_area--title">
+                        ${item.name}
+                      </div>
+                      <div class="one_item__text_area--price">
+                        ¥${item.price}
+                        <span>
+                          <i class="fa fa-heart-o"></i>
+                          8
+                        </span>
+                      </div>
+                    </div>
+                  </a>
+                  `
+    }else{
+      var html = `
+                  <a class="one_item search_item" href="/items/${item.id}">
+                    <div class="one_item__image_area">
+                      <img src="${window.location.origin}${item.image}">
+                    </div>
+                    <div class="one_item__text_area">
+                      <div class="one_item__text_area--title">
+                        ${item.name}
+                      </div>
+                      <div class="one_item__text_area--price">
+                        ¥${item.price}
+                        <span>
+                          <i class="fa fa-heart-o"></i>
+                          8
+                        </span>
+                      </div>
+                    </div>
+                  </a>
+                  `
+    }
+    $(".main_block__item").append(html);
+  }
+
+  $(".incremental").on("keyup",function(event){
+    if(event.code === "Space"){
+      return;
+    }else{
+      
+      let input = $(this).val();
+      $.ajax({
+        method: "GET",
+        url: "./incremental",
+        data: { keyword: input },
+        dataType: "json",
+      }).done(function(data){
+        $(".main_block__item").empty();
+        if(data["keyword"] === ""){
+          $(".main_block__text__keyword").text("無効な入力です。");
+        } else if(data["hit_count"] === 0){
+          $(".main_block__text__keyword").text("申し訳ありません！お探しの商品はありませんでした");
+          $(".main_block__text__hit_count").text("0 件表示");
+        } else {
+          $(".main_block__text__keyword").text(data["keyword"] + " の検索結果");
+          $(".main_block__text__hit_count").text(data["hit_count"] + " 件表示");
+        }
+        data["items"].forEach(function(item){
+          appendItem(item)
+        });
+        if(event.key === "Backspace"){
+          if(input === ""){
+            $(".main_block__item").empty();
+          }
+        }
+      }).fail(function(){
+        alert("アイテム検索に失敗しました");
+      });
+    }
+  });
+})

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -74,6 +74,7 @@ $(function(){
         if(event.key === "Backspace"){
           if(input === ""){
             $(".main_block__item").empty();
+            $(".main_block__text__hit_count").text("0 件表示");
           }
         }
       }).fail(function(){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,7 @@
 @import "./detail";
 @import "./credit_index_page";
 @import "./credit_new_page";
-
+@import "./search_page";
 
 /*
  

--- a/app/assets/stylesheets/item-part.scss
+++ b/app/assets/stylesheets/item-part.scss
@@ -1,12 +1,12 @@
-.one-item {
+.one_item {
   width: 200px;
-  height: inherit;
+  height: 320px;
   text-align: left;
   color: $black;
   &:hover {
     opacity: 1;
     color: $black;
-   text-decoration: none;
+    text-decoration: none;
   }
   &__image_area {
     height: 70%;

--- a/app/assets/stylesheets/search_page.scss
+++ b/app/assets/stylesheets/search_page.scss
@@ -1,0 +1,54 @@
+.item_search_page{
+  background-color: $gray;
+  .container{
+    width: 85%;
+    min-height: 100vh;
+    margin: 0 auto;
+    padding: 40px 0;
+    display: flex;
+    flex-wrap: nowrap;
+  }
+  .left-column{
+    padding: 40px auto;
+    width: 20%;
+    margin: 0 30px 0 0;
+    .search-panel{
+      background-color: $white;
+      input{
+        width: 100%;
+        height: 40px;
+        padding: 0 8px;
+        
+      }
+    }
+  }
+  .right-column{
+    width: 80%;
+    text-decoration: none;
+    .main_block{
+      h2{
+        margin: 0 0 20px;
+        font-size: 24px;
+      }
+      p {
+        margin: 0 0 20px;
+        color: #ccc;
+        font-size: 14px;
+      }
+      &__item{
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        .one_item{
+          margin-right: 30px;
+          margin-bottom: 30px;
+        }
+        @include disable-link-decoration();
+      }
+    }
+  }
+  .search_item{
+    width: 170px;
+    height: 320px;
+  }
+}

--- a/app/assets/stylesheets/top_page_main.scss
+++ b/app/assets/stylesheets/top_page_main.scss
@@ -30,9 +30,9 @@
           padding-bottom: 40px;
         }
         .main_block_new_items_area {
-          height: 320px;
           display: flex;
           justify-content: space-between;
+          @include disable-link-decoration();
         }
         .link_to_items {
           padding-top: 10px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,7 +53,7 @@ class ItemsController < ApplicationController
     @keyword = keyword_params[:keyword]
     @items = []
     @items.push(Item.where('name LIKE(?)', "%#{@keyword}%"))
-    if @keyword.class == "Integer"
+    if @keyword.to_i > 0
       @items.push(Item.where('price = ?', @keyword))
       @items.push(Item.where('price < ? ', @keyword).where('price > ? ', @keyword * 0.9).limit(10))
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,8 +54,8 @@ class ItemsController < ApplicationController
     @items = []
     @items.push(Item.where('name LIKE(?)', "%#{@keyword}%"))
     if @keyword.to_i > 0
-      @items.push(Item.where('price = ?', @keyword))
-      @items.push(Item.where('price < ? ', @keyword).where('price > ? ', @keyword * 0.9).limit(10))
+      @items.push(Item.where('price = ?', @keyword.to_i))
+      @items.push(Item.where('price < ? ', @keyword.to_i).where('price > ? ', @keyword.to_i * 0.9).limit(10))
     end
     @items.flatten!
     @items.uniq!

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,24 +1,24 @@
 
 - if item.buy_history.present?
-  = link_to item, class: "new_item item_soldout__parent" do
-    .new_item__image_area.item_soldout__children
+  = link_to item, class: "one_item item_soldout__parent search_item" do
+    .one_item__image_area.item_soldout__children
       = image_tag item.images[0]
-    .new_item__text_area
-      .new_item__text_area--title
+    .one_item__text_area
+      .one_item__text_area--title
         = item.name
-      .new_item__text_area--price
+      .one_item__text_area--price
         = "¥#{item.price}"
         %span
           = fa_icon "heart-o"
           8
 - else 
-  = link_to item, class: "new_item" do
-    .new_item__image_area
+  = link_to item, class: "one_item search_item" do
+    .one_item__image_area
       = image_tag item.images[0]
-    .new_item__text_area
-      .new_item__text_area--title
+    .one_item__text_area
+      .one_item__text_area--title
         = item.name
-      .new_item__text_area--price
+      .one_item__text_area--price
         = "¥#{item.price}"
         %span
           = fa_icon "heart-o"

--- a/app/views/items/incremental.json.jbuilder
+++ b/app/views/items/incremental.json.jbuilder
@@ -1,0 +1,13 @@
+json.set! :keyword, @keyword
+json.set! :hit_count, @items.length
+
+json.set! :items do
+  json.array! @items do |item|
+    json.id item.id
+    json.name item.name
+    json.price item.price
+    json.description item.description
+    json.buy_history item.buy_history.present?
+    json.image url_for(item.images[0])
+  end
+end

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,21 @@
+.item_search_page
+  = render "shared/header"
+  .container
+    .left-column
+      .search-panel
+        = form_with url: incremental_items_path ,method: :get ,class: "header_search" do |f| 
+          = f.text_field :keyword ,{class: "header_search__input incremental", placeholder: "インクリメンタルサーチ！"}
+    .right-column
+      .main_block
+        .main_block__text
+          %h2
+            %span.main_block__text__keyword
+              = "#{@keyword}の検索結果"
+          %p
+            %span.main_block__text__hit_count
+              = "#{@items.length}件表示"
+        .main_block__item
+          = render @items
+  = render "shared/footer"
+  = render "shared/new_item_button"
+

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -5,12 +5,15 @@
         = link_to root_path do
           = image_tag "logo.svg"
       .header_container_top_right
-        %form.header_search
-          %input(type="text" class="header_search__input" placeholder="何かお探しですか？")
-          %lebel(for="search" class="search_label")
-            = fa_icon "search"
-          %input(type="submit" value="送信" class="header_search__submit" id="search")
-        
+        - if controller.controller_name == "items" && action_name == "search"
+          = form_with url: incremental_items_path ,method: :get ,class: "header_search" do |f| 
+            = f.text_field :keyword ,{class: "header_search__input incremental", placeholder: "何かお探しですか？"}
+        - else
+          = form_with url: search_items_path ,local: true, method: :get ,class: "header_search" do |f| 
+            = f.text_field :keyword ,{class: "header_search__input", placeholder: "何かお探しですか？"}
+            = f.label :search, {class: "search_label"} do
+              = fa_icon "search"
+            = f.submit "送信", {class: "header_search__submit", id: "search"}        
     .header_container_bottom
       .header_container_bottom__category
         %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :credits, only: [:index, :new, :create, :destroy]
   resources :items, only: [:index,:new,:create,:show, :edit, :update, :destroy] do
+    collection do
+      get 'search'
+      get 'incremental'
+    end
     resources :buy_histories, only: [:new, :create]
     member do
       get 'preview'


### PR DESCRIPTION
# What
ヘッダーの検索バーを用いて商品を検索できるようにしました。
検索バーで検索ページに行った後、インクリメンタルサーチによる商品検索をできるようにしました。

# Why
ユーザがスムーズに目的の商品にたどり着くことができるようにするため

# 実装方法
Active::Storageの画像の場所をJSで参照するのは無理でしたので、
Active::Storageの永続リンク機能を用いて実装しました。
`url_for(item.images[0])`のようにすると5分間アクセスできるリンクが作成されます。
その為、一度表示した商品のプレビューは高速になりました。リンクが貼られていない商品のプレビュー表示は数秒の遅延があります。

# スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/a34506d505209322b1e739fc49943f5a.gif)](https://gyazo.com/a34506d505209322b1e739fc49943f5a)
[![Image from Gyazo](https://i.gyazo.com/de18876303a373db1abf3a987239af56.gif)](https://gyazo.com/de18876303a373db1abf3a987239af56)
<img width="1215" alt="スクリーンショット 2019-07-15 15 25 35" src="https://user-images.githubusercontent.com/15213843/61198407-d2d6fc80-a714-11e9-816a-99cba983a304.png">
