### PR TITLE
Top page category

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,8 +4,8 @@ class ItemsController < ApplicationController
 
   def index
     @latest_items = Item.limit(20).order("id DESC")
-    @ladys = Item.where("category_id = 1")
-    @mens = Item.where("category_id = 2")
+    @ladys = Item.where("category_id = 1").limit(4).order("id DESC")
+    @mens = Item.where("category_id = 2").limit(4).order("id DESC")
   end
   
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,9 @@ class ItemsController < ApplicationController
   before_action :set_item, except: [:index,:create,:new,:search,:incremental]
 
   def index
-    @items = Item.limit(20).order("id DESC")
+    @latest_items = Item.limit(20).order("id DESC")
+    @ladys = Item.where("category_id = 1")
+    @mens = Item.where("category_id = 2")
   end
   
   def new

--- a/app/views/shared/_top_page_main.html.haml
+++ b/app/views/shared/_top_page_main.html.haml
@@ -4,58 +4,19 @@
     .categocies.main_block
       .pick_up_category_ladies.main_block_new_items
         %h2
-          = link_to "全ての新着アイテム", "#"
+          = link_to "レディースの新着アイテム", "#"
         .main_block_new_items_area
+          - @items = @ladys
           = render @items
-  -#     .pick_up_category_mens.main_block_new_items
-  -#       %h2
-  -#         = link_to "メンズ 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -#     .pick_up_category_babies.main_block_new_items
-  -#       %h2
-  -#         = link_to "ベビー・キッズ 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -#     .pick_up_category_cosme.main_block_new_items
-  -#       %h2 
-  -#         = link_to "コスメ・香水・美容 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -# .pick_up_bland.wrapper
-  -#   %h1 ピックアップブランド
-  -#   .blands.new_items.main_block
-  -#     .pick_up_bland_chanel.main_block_new_items
-  -#       %h2
-  -#         = link_to "シャネル 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -#     .pick_up_bland_vuitton.main_block_new_items
-  -#       %h2 
-  -#         = link_to "ルイヴィトン 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -#     .pick_up_bland_supreme.main_block_new_items
-  -#       %h2 
-  -#         = link_to "シュプリーム 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
-  -#     .pick_up_bland_nike.main_block_new_items
-  -#       %h2
-  -#         = link_to "ナイキ 新着アイテム", "#"
-  -#       .main_block_new_items_area
-  -#         = render @items
-  -#       %p.link_to_items
-  -#         = link_to "すべての商品を見る", "#"
+      .pick_up_category_mens.main_block_new_items
+        %h2
+          = link_to "メンズ 新着アイテム", "#"
+        .main_block_new_items_area
+          - @items = @mens
+          = render @items
+      .pick_up_category_mens.main_block_new_items
+        %h2
+          = link_to "新着アイテム", "#"
+        .main_block_new_items_area
+          - @items = @latest_items
+          = render @items

--- a/app/views/shared/_top_page_main.html.haml
+++ b/app/views/shared/_top_page_main.html.haml
@@ -4,7 +4,7 @@
     .categocies.main_block
       .pick_up_category_ladies.main_block_new_items
         %h2
-          = link_to "レディースの新着アイテム", "#"
+          = link_to "レディース 新着アイテム", "#"
         .main_block_new_items_area
           - @items = @ladys
           = render @items


### PR DESCRIPTION
## WHAT
トップページで新着カテゴリー別に表示

## WHY
ユーザーがカテゴリー別で新着を見れるようにし購入にいたるまでの過程を短縮

- スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/c1f46dee3ecd3f3d63de0a94e860dbea.gif)](https://gyazo.com/c1f46dee3ecd3f3d63de0a94e860dbea)